### PR TITLE
Fixing comments on yearly tabs

### DIFF
--- a/src/sheets/assets/formatting_configs/overview_notes.json
+++ b/src/sheets/assets/formatting_configs/overview_notes.json
@@ -4,7 +4,6 @@
     "F2": "FSA and Medical",
     "G2": "Medicare, Federal, State, City, NYPFL, Disability, and Social Security",
     "H2": "Pre Tax or Roth",
-    "I2": "HSA Contribution",
     "J2": "Critical Illness, AD & D, Long Term Disability",
     "K2": "Pre-Tax Deductions + Taxes + HSA Contribution + Post-Tax Deductions",
     "L2": "Gross Earnings - Total Deductions",

--- a/src/sheets/assets/formatting_configs/yearly_categories_notes.json
+++ b/src/sheets/assets/formatting_configs/yearly_categories_notes.json
@@ -1,8 +1,6 @@
 {
     "B3": "Gross Earnings",
-    "B4": "Salary",
-    "B5": "Bonus",
-    "B6": "FSA and Medical",
+    "B4": "FSA and Medical",
     "B7": "Medicare, Federal, State, City, NYPFL, Disability, and Social Security",
     "B8": "Pre Tax or Roth",
     "B9": "HSA Contribution",

--- a/src/sheets/assets/formatting_configs/yearly_categories_notes.json
+++ b/src/sheets/assets/formatting_configs/yearly_categories_notes.json
@@ -1,6 +1,7 @@
 {
     "B3": "Gross Earnings",
     "B4": "FSA and Medical",
+    "B6": "Includes Bonus, PTO Payout, and Severance",
     "B7": "Medicare, Federal, State, City, NYPFL, Disability, and Social Security",
     "B8": "Pre Tax or Roth",
     "B9": "HSA Contribution",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates sheet notes: remove `I2` in overview and reorganize early income labels in yearly categories (move FSA to `B4`, consolidate bonus-related note at `B6`).
> 
> - **Sheets formatting notes**:
>   - `src/sheets/assets/formatting_configs/overview_notes.json`:
>     - Remove `I2` note for `HSA Contribution`.
>   - `src/sheets/assets/formatting_configs/yearly_categories_notes.json`:
>     - Reorganize early income labels: move `FSA and Medical` to `B4`; replace `Salary`/`Bonus` with consolidated `Includes Bonus, PTO Payout, and Severance` at `B6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3ee4b0f98c579d30ce78cf794e0c231f63b24fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->