### PR TITLE
feat(warehouse): add Savings 5% adherence bucket (re-slice 20% → 15/5)

### DIFF
--- a/src/warehouse/sqlmesh_project/audits/yearly_income_derivation_bucket_targets_sum.sql
+++ b/src/warehouse/sqlmesh_project/audits/yearly_income_derivation_bucket_targets_sum.sql
@@ -7,7 +7,8 @@ SELECT
   needs_target,
   wants_target,
   investments_target,
+  savings_target,
   allocatable_income,
-  needs_target + wants_target + investments_target AS calculated_total
+  needs_target + wants_target + investments_target + savings_target AS calculated_total
 FROM @this_model
-WHERE NOT abs((needs_target + wants_target + investments_target) - allocatable_income) < 0.02;
+WHERE NOT abs((needs_target + wants_target + investments_target + savings_target) - allocatable_income) < 0.02;

--- a/src/warehouse/sqlmesh_project/audits/yearly_savings_adherence_on_plan_consistency.sql
+++ b/src/warehouse/sqlmesh_project/audits/yearly_savings_adherence_on_plan_consistency.sql
@@ -1,0 +1,13 @@
+AUDIT (
+  name yearly_savings_adherence_on_plan_consistency
+);
+
+SELECT
+  year,
+  bucket,
+  projected,
+  target,
+  on_plan_flag
+FROM @this_model
+WHERE target IS NOT NULL
+  AND on_plan_flag <> (projected >= target);

--- a/src/warehouse/sqlmesh_project/audits/yearly_savings_adherence_overage_consistency.sql
+++ b/src/warehouse/sqlmesh_project/audits/yearly_savings_adherence_overage_consistency.sql
@@ -1,0 +1,14 @@
+AUDIT (
+  name yearly_savings_adherence_overage_consistency
+);
+
+SELECT
+  year,
+  bucket,
+  target,
+  projected,
+  overage_pct
+FROM @this_model
+WHERE target IS NOT NULL
+  AND target <> 0
+  AND NOT abs(overage_pct - ((projected - target) / target)) < 0.0001;

--- a/src/warehouse/sqlmesh_project/models/_4_core/yearly_income_derivation.sql
+++ b/src/warehouse/sqlmesh_project/models/_4_core/yearly_income_derivation.sql
@@ -6,7 +6,7 @@ MODEL (
     yearly_income_derivation_allocatable_invariant,
     yearly_income_derivation_bucket_targets_sum
   ),
-  description 'Per-year salary, estimated tax (cadence-based extrapolation for the current year), HSA, allocatable income, and 50/30/20 bucket targets.'
+  description 'Per-year salary, estimated tax (cadence-based extrapolation for the current year), HSA, allocatable income, and 50/30/15/5 bucket targets (Needs/Wants/Investments/Savings).'
 );
 
 with paystub_periods as (
@@ -118,8 +118,8 @@ with paystub_periods as (
 , allocatable as (
     /*
         Join annual_contributions for hsa and compute allocatable_income
-        once. The final select then multiplies by 0.50 / 0.30 / 0.20 for
-        bucket targets without restating the subtraction.
+        once. The final select then multiplies by 0.50 / 0.30 / 0.15 / 0.05
+        for bucket targets without restating the subtraction.
     */
     select
         scaled.year
@@ -146,7 +146,8 @@ select
     , allocatable_income
     , round(allocatable_income * 0.50, 2) as needs_target
     , round(allocatable_income * 0.30, 2) as wants_target
-    , round(allocatable_income * 0.20, 2) as investments_target
+    , round(allocatable_income * 0.15, 2) as investments_target
+    , round(allocatable_income * 0.05, 2) as savings_target
     , is_extrapolated
     , latest_pay_date
 from allocatable

--- a/src/warehouse/sqlmesh_project/models/_4_core/yearly_savings_adherence.sql
+++ b/src/warehouse/sqlmesh_project/models/_4_core/yearly_savings_adherence.sql
@@ -1,0 +1,127 @@
+MODEL (
+  name core.yearly_savings_adherence,
+  kind FULL,
+  grain (year),
+  audits (
+    not_null(columns := (year, bucket)),
+    unique_values(columns := (year)),
+    yearly_savings_adherence_overage_consistency,
+    yearly_savings_adherence_on_plan_consistency
+  ),
+  description 'Per-year Savings-bucket (5%) adherence. Savings is the single YNAB `Savings` category. Net saved = budgeted - spent, where spend withdrawn from savings is meant to be covered by §8 extra income: net_saved = savings_budgeted - max(0, savings_spent - extra_covered). Unlike Needs/Wants, more is better: on_plan_flag is projected >= target. This model emits the PRE-COVERAGE view (extra_covered = 0) plus the savings_budgeted / savings_spent components the §8 extra-income patch consumes; the coverage-adjusted adherence is produced downstream once §8 (and its §1 extra-income input) exist. Investments and Savings are the two more-is-good buckets, both excluded from core.yearly_bucket_adherence.'
+);
+
+with savings_months as (
+    /*
+        Per-month budgeted and net activity for the single `Savings` category.
+        The `Savings` group holds exactly this one category, so filtering the
+        group isolates it. activity_usd is negative for spend in YNAB.
+
+        Exclude budget months that have not elapsed yet: YNAB pre-creates
+        future budget-month rows (zero activity) for scheduled/goal categories,
+        which would inflate months_with_data and distort the current-year
+        extrapolation.
+
+        Join monthly_categories.category_group_id directly to
+        category_groups.id rather than hopping through cleaned.categories — the
+        as-of-month affiliation lives on monthly_categories itself.
+    */
+    select
+        monthly_categories.year as year
+        , monthly_categories.month as month
+        , sum(monthly_categories.budgeted_usd) as budgeted_usd
+        , sum(monthly_categories.activity_usd) as activity_usd
+    from cleaned.monthly_categories as monthly_categories
+    inner join cleaned.category_groups as category_groups
+        on monthly_categories.category_group_id = category_groups.id
+    where category_groups.category_group_name_mapping = 'Savings'
+        and coalesce(monthly_categories.deleted, false) = false
+        and make_date(monthly_categories.year, monthly_categories.month, 1)
+            <= date_trunc('month', current_date())
+    group by 1, 2
+)
+
+, savings_years as (
+    /*
+        Year-level YTD assigned and withdrawn dollars, plus the count of
+        elapsed budget months that drives current-year extrapolation.
+        savings_spent_ytd is net withdrawal (sign-flipped activity) floored at
+        0 so a net-inflow year reads as zero spend, not negative.
+    */
+    select
+        year
+        , round(sum(budgeted_usd), 2) as savings_budgeted_ytd
+        , round(greatest(0, -1 * sum(activity_usd)), 2) as savings_spent_ytd
+        , count(distinct month) as months_with_data
+    from savings_months
+    group by 1
+)
+
+, projected as (
+    /*
+        Drive off income_derivation so every year with a savings_target gets a
+        row even when no savings activity exists yet. Current year extrapolates
+        YTD assigned and withdrawn across elapsed months to a full year; past
+        years pass YTD through.
+
+        extra_covered is the §8 extra-income coverage of savings spend. It is
+        hard-zero here: the §8 patch model (and its §1 extra-income input) do
+        not exist yet, so this model reports the pre-coverage floor. When §8
+        lands, the coverage-adjusted net_saved = savings_budgeted -
+        max(0, savings_spent - extra_covered) is produced downstream, consuming
+        the savings_spent component surfaced below.
+    */
+    select
+        income.year as year
+        , income.savings_target as target
+        , income.year = cast(extract('year' from current_date()) as integer) as is_extrapolated
+        , case
+            when income.year = cast(extract('year' from current_date()) as integer)
+                 and coalesce(savings_years.months_with_data, 0) > 0
+                then round(savings_years.savings_budgeted_ytd / savings_years.months_with_data * 12, 2)
+            else round(coalesce(savings_years.savings_budgeted_ytd, 0), 2)
+        end as savings_budgeted
+        , case
+            when income.year = cast(extract('year' from current_date()) as integer)
+                 and coalesce(savings_years.months_with_data, 0) > 0
+                then round(savings_years.savings_spent_ytd / savings_years.months_with_data * 12, 2)
+            else round(coalesce(savings_years.savings_spent_ytd, 0), 2)
+        end as savings_spent
+        , 0::decimal as extra_covered  -- §8 coverage not yet wired; pre-coverage floor
+    from core.yearly_income_derivation as income
+    left join savings_years
+        on income.year = savings_years.year
+)
+
+, netted as (
+    select
+        year
+        , target
+        , savings_budgeted
+        , savings_spent
+        , extra_covered
+        , round(savings_budgeted - greatest(0, savings_spent - extra_covered), 2) as projected
+        , is_extrapolated
+    from projected
+)
+
+select
+    year
+    , 'Savings' as bucket
+    , target
+    , savings_budgeted
+    , savings_spent
+    , extra_covered
+    , projected  -- Pre-coverage net saved (budgeted - spent); §8 coverage credits covered spend back downstream
+    , case
+        when target is null or target = 0
+            then null
+        else round((projected - target) / target, 4)
+    end as overage_pct  -- More-is-good: positive means the savings goal was exceeded
+    , case
+        when target is null then null
+        else projected >= target
+    end as on_plan_flag  -- More-is-good: on plan when projected meets or beats target
+    , is_extrapolated
+from netted
+order by year desc


### PR DESCRIPTION
## Summary

Splits the 20% Investments allocation into **15% Investments + 5% Savings** (rule becomes **50/30/15/5**). Savings is the single YNAB `Savings` category — a *more-is-good* bucket measured as `budgeted − spent`, tracked by a new core model separate from the Needs/Wants rollup (mirrors how Investments is handled).

Ticket: **ETH-477**. Plan ref: Financial Plan §2/§4/§5/§8 (Savings carve-out).

## What changed

- `models/_4_core/yearly_income_derivation.sql` — `investments_target` 20% → 15%, add `savings_target` (5%).
- `audits/yearly_income_derivation_bucket_targets_sum.sql` — now sums all four targets to `allocatable_income`.
- `models/_4_core/yearly_savings_adherence.sql` — **new**. Outputs `year, bucket, target, savings_budgeted, savings_spent, extra_covered, projected, overage_pct, on_plan_flag, is_extrapolated`. `on_plan_flag = projected >= target` (more-is-good polarity), current-year extrapolation, elapsed-month filter.
- `audits/yearly_savings_adherence_overage_consistency.sql` + `..._on_plan_consistency.sql` — **new** (mirror the bucket-adherence audits with `>=`).

## Coverage-ready, not yet coverage-active

The savings signal is `net_saved = savings_budgeted − max(0, savings_spent − extra_covered)`. Withdrawals from savings are meant to be backfilled by §8 extra income, but that input doesn't exist yet, so this model exposes the `savings_budgeted` / `savings_spent` components and emits the **pre-coverage floor** (`extra_covered = 0`). Real coverage activates once **ETH-476** (`extra_income` column) and **ETH-470** (§8 patch) land.

## Verification

- Logic validated against the local warehouse: pre-coverage net matches prior figures; full coverage flips several years to on-plan (specific per-year amounts kept out of this description).
- Adherence enforced by the two new consistency audits + `not_null` / `unique_values` on the grain.
- `uv run pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)