### PR TITLE
feat(warehouse): add extra_income to core.yearly_income_derivation (ETH-476)

### DIFF
--- a/src/warehouse/sqlmesh_project/audits/yearly_income_derivation_paystub_inflows_reconcile.sql
+++ b/src/warehouse/sqlmesh_project/audits/yearly_income_derivation_paystub_inflows_reconcile.sql
@@ -1,0 +1,31 @@
+AUDIT (
+  name yearly_income_derivation_paystub_inflows_reconcile
+);
+
+/*
+    Every Ready-to-Assign (`Income`) inflow linked to a paystub must reconcile
+    to that paystub's net deposit (net_pay + reimbursements). extra_income is
+    "total Income inflows minus salary paychecks"; if a paycheck under- or
+    over-linked, the salary it removes would be wrong and the leftover extra
+    would drift. net_pay lands once per paystub (daily_ledger nulls it on
+    non-primary split rows), so summing per deposit-year reconciles cleanly.
+*/
+WITH linked_by_year AS (
+  SELECT
+    CAST(EXTRACT('year' FROM ledger_date) AS INTEGER) AS year,
+    ROUND(SUM(transaction_amount_usd), 2) AS linked_inflow,
+    ROUND(SUM(COALESCE(net_pay, 0) + COALESCE(income_for_reimbursements, 0)), 2) AS paystub_deposit
+  FROM core.daily_ledger
+  WHERE category_group_name_mapping = 'Income'
+    AND paystub_file_name IS NOT NULL
+  GROUP BY 1
+)
+SELECT
+  m.year,
+  l.linked_inflow,
+  l.paystub_deposit,
+  ROUND(l.linked_inflow - l.paystub_deposit, 2) AS diff
+FROM @this_model AS m
+JOIN linked_by_year AS l
+  ON m.year = l.year
+WHERE ROUND(l.linked_inflow, 2) != ROUND(l.paystub_deposit, 2);

--- a/src/warehouse/sqlmesh_project/models/_4_core/yearly_income_derivation.sql
+++ b/src/warehouse/sqlmesh_project/models/_4_core/yearly_income_derivation.sql
@@ -4,9 +4,10 @@ MODEL (
   grain (year),
   audits (
     yearly_income_derivation_allocatable_invariant,
-    yearly_income_derivation_bucket_targets_sum
+    yearly_income_derivation_bucket_targets_sum,
+    yearly_income_derivation_paystub_inflows_reconcile
   ),
-  description 'Per-year salary, estimated tax (cadence-based extrapolation for the current year), HSA, allocatable income, and 50/30/15/5 bucket targets (Needs/Wants/Investments/Savings).'
+  description 'Per-year salary, estimated tax (cadence-based extrapolation for the current year), HSA, allocatable income, 50/30/15/5 bucket targets (Needs/Wants/Investments/Savings), and extra_income (net-to-account one-off inflows: bonus/severance/PTO payout/refunds/interest/cashback, actual YTD, not extrapolated; does not feed allocatable_income).'
 );
 
 with paystub_periods as (
@@ -138,17 +139,45 @@ with paystub_periods as (
         on scaled.year = annual_contributions.year
 )
 
+, extra_income_by_year as (
+    /*
+        Per-year extra income: every net inflow assigned to Ready-to-Assign
+        (the YNAB `Income` mapping) that is NOT a regular-salary paycheck.
+        core.daily_ledger links each paycheck deposit to its paystub, so
+        excluding inflows linked to a salary paystub (earnings_salary_usd > 0)
+        strips net salary without payee matching or a salary double-count.
+        What remains is net-to-account one-off income: bonus, severance, PTO
+        payout, tax refunds, interest, cashback, and side deposits. Actual YTD
+        for the current year — one-offs are never extrapolated. Join on the
+        unique paystub file_name (not daily_ledger's rank-gated salary column)
+        so a split paycheck is still classified by its paystub type.
+    */
+    select
+        cast(extract('year' from daily_ledger.ledger_date) as integer) as year
+        , round(sum(daily_ledger.transaction_amount_usd), 2) as extra_income
+    from core.daily_ledger as daily_ledger
+    left join cleaned.paystubs as paystubs
+        on daily_ledger.paystub_file_name = paystubs.file_name
+    where daily_ledger.category_group_name_mapping = 'Income'
+        and daily_ledger.transaction_amount_usd > 0
+        and coalesce(paystubs.earnings_salary_usd, 0) = 0
+    group by 1
+)
+
 select
-    year
-    , salary
-    , estimated_tax
-    , hsa
-    , allocatable_income
-    , round(allocatable_income * 0.50, 2) as needs_target
-    , round(allocatable_income * 0.30, 2) as wants_target
-    , round(allocatable_income * 0.15, 2) as investments_target
-    , round(allocatable_income * 0.05, 2) as savings_target
-    , is_extrapolated
-    , latest_pay_date
+    allocatable.year
+    , allocatable.salary
+    , allocatable.estimated_tax
+    , allocatable.hsa
+    , allocatable.allocatable_income
+    , round(allocatable.allocatable_income * 0.50, 2) as needs_target
+    , round(allocatable.allocatable_income * 0.30, 2) as wants_target
+    , round(allocatable.allocatable_income * 0.15, 2) as investments_target
+    , round(allocatable.allocatable_income * 0.05, 2) as savings_target
+    , coalesce(extra_income_by_year.extra_income, 0) as extra_income
+    , allocatable.is_extrapolated
+    , allocatable.latest_pay_date
 from allocatable
-order by year desc
+left join extra_income_by_year
+    on allocatable.year = extra_income_by_year.year
+order by allocatable.year desc


### PR DESCRIPTION
## What

Adds a per-year `extra_income` column to `core.yearly_income_derivation` — the `extra_income` output specced in ETH-467 but never built in PR #40. Unblocks the ETH-470 §8 Savings-coverage patch, which needs a per-year extra-income figure.

## Definition (net to account)

`extra_income` = per-year sum of all Ready-to-Assign (`category_group_name_mapping = 'Income'`) net inflows in `core.daily_ledger` that are **not** regular-salary paychecks — i.e. tax refunds, interest, cashback, side deposits, plus net bonus/severance/PTO payout.

- **Salary excluded via the `daily_ledger` paystub link**, not payee text: join `cleaned.paystubs` on the unique `file_name` and keep rows where `coalesce(paystubs.earnings_salary_usd, 0) = 0`. This avoids the net-salary double-count that summing the `Income` mapping wholesale would cause (salary deposits also land in Ready-to-Assign).
- **Net to account** — bonuses arrive as separate pure-bonus paychecks (`earnings_salary_usd = 0`), so their net deposit is included; severance and PTO payout count as bonus too.
- **Actual YTD, never extrapolated** (one-offs); does **not** feed `allocatable_income`.

## Audit

Adds `yearly_income_derivation_paystub_inflows_reconcile` — guards the salary exclusion by asserting, per deposit-year, that paystub-linked Income inflows equal the linked paystubs' net deposits (`net_pay + income_for_reimbursements`).

## Verification

- `uv run pre-commit run --all-files` and `uv run pytest` (34 passed)
- Full `sqlmesh plan --auto-apply`: all 39 models rebuilt; `core.yearly_income_derivation` audits passed 3 (allocatable invariant, bucket targets sum, paystub inflows reconcile), and all downstream consumers rebuilt clean.
- Materialized `extra_income` reviewed locally against expected per-year values (kept out of this description).

Closes ETH-476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)