### PR TITLE
feat(warehouse): §8 emergency-fund contribution-funding step (ETH-479)

### DIFF
--- a/src/warehouse/sqlmesh_project/audits/yearly_extra_income_allocation_conservation.sql
+++ b/src/warehouse/sqlmesh_project/audits/yearly_extra_income_allocation_conservation.sql
@@ -7,12 +7,14 @@ SELECT
   extra_income,
   extra_income_used_for_needs_overage
     + extra_income_used_for_wants_overage
+    + extra_income_used_for_emergency_fund_contributions
     + extra_income_used_for_savings_coverage
     + extra_income_surplus_to_investments AS allocated_total
 FROM @this_model
 WHERE NOT abs(
   (extra_income_used_for_needs_overage
    + extra_income_used_for_wants_overage
+   + extra_income_used_for_emergency_fund_contributions
    + extra_income_used_for_savings_coverage
    + extra_income_surplus_to_investments) - extra_income
 ) < 0.02;

--- a/src/warehouse/sqlmesh_project/models/_4_core/yearly_extra_income_allocation.sql
+++ b/src/warehouse/sqlmesh_project/models/_4_core/yearly_extra_income_allocation.sql
@@ -9,10 +9,28 @@ MODEL (
     yearly_extra_income_allocation_savings_on_plan_consistency,
     yearly_extra_income_allocation_overage_on_plan_consistency
   ),
-  description 'Per-year §8 extra-income patch: waterfalls extra_income (§1 net one-off inflows) across Needs overage → Wants overage → Savings coverage → Investments surplus. Emits the four patch figures (which sum to extra_income) plus the coverage-adjusted savings net_saved / on_plan and the per-bucket on-plan-after-allocation flags (needs/wants on plan when the patch fully absorbed the overage; savings on plan when net_saved_after_coverage >= target). The Investments on-plan-after-surplus flag lives in core.yearly_investment_contributions (importing investment actuals here would form a cycle). Overage patches do NOT inflate Needs/Wants targets (buckets stay flagged in core.yearly_bucket_adherence); savings coverage credits covered spend back without raising the savings target or funding new savings. extra_income_surplus_to_investments feeds core.yearly_investment_contributions (ETH-470 step 4), where it augments the salary-based investments_target and re-splits 50/50 with employee-limit spillover.'
+  description 'Per-year §8 extra-income patch: waterfalls extra_income (§1 net one-off inflows) across Emergency Fund contributions → Needs overage → Wants overage → Savings coverage → Investments surplus. Emits the five patch figures (which sum to extra_income) plus the coverage-adjusted savings net_saved / on_plan and the per-bucket on-plan-after-allocation flags (needs/wants on plan when the patch fully absorbed the overage; savings on plan when net_saved_after_coverage >= target). The Investments on-plan-after-surplus flag lives in core.yearly_investment_contributions (importing investment actuals here would form a cycle). extra_income_used_for_emergency_fund_contributions is priority 1, funded off the top of extra_income and capped at emergency_fund_assigned (gross Emergency Fund group assignments per core.monthly_budgeted = the _5 dashboards emergency_fund_saved figure, actual YTD, not extrapolated): the full EF top-up made that year is recognized first whenever extra_income covers it. Overage patches do NOT inflate Needs/Wants targets (buckets stay flagged in core.yearly_bucket_adherence). Savings coverage credits covered (actual-YTD) spend back without raising any target/goal. extra_income_surplus_to_investments feeds core.yearly_investment_contributions (ETH-470 step 4), where it augments the salary-based investments_target and re-splits 50/50 with employee-limit spillover.'
 );
 
-with bucket_pivot as (
+with emergency_assigned as (
+    /*
+        Per-year Emergency Fund contributions = what was assigned/budgeted to the
+        Emergency Fund group. Sourced from core.monthly_budgeted so it equals the
+        figure surfaced in the _5 dashboards layer
+        (dashboards.*.emergency_fund_saved). Gross assigned, floored at 0.
+        Actual YTD (elapsed budget months only) — emergency top-ups are lumpy
+        one-offs, and the extra_income pool funding them is itself actual YTD, so
+        this is NOT extrapolated.
+    */
+    select
+        cast(extract('year' from budget_month) as integer) as year
+        , greatest(0, round(sum(emergency_fund_assigned), 2)) as emergency_fund_assigned
+    from core.monthly_budgeted
+    where budget_month <= date_trunc('month', current_date())
+    group by 1
+)
+
+, bucket_pivot as (
     /*
         Pivot core.yearly_bucket_adherence from one row per (year, bucket) to
         one row per year with Needs/Wants projected + target side by side, so the
@@ -44,6 +62,7 @@ with bucket_pivot as (
         , coalesce(bucket_pivot.needs_target, 0) as needs_target
         , coalesce(bucket_pivot.wants_projected, 0) as wants_projected
         , coalesce(bucket_pivot.wants_target, 0) as wants_target
+        , coalesce(emergency_assigned.emergency_fund_assigned, 0) as emergency_fund_assigned
         , coalesce(savings.savings_budgeted, 0) as savings_budgeted
         , coalesce(savings.savings_spent, 0) as savings_spent
         , savings.target as savings_target
@@ -53,31 +72,52 @@ with bucket_pivot as (
     from core.yearly_income_derivation as income
     left join bucket_pivot
         on income.year = bucket_pivot.year
+    left join emergency_assigned
+        on income.year = emergency_assigned.year
     left join core.yearly_savings_adherence as savings
         on income.year = savings.year
 )
 
-, needs_step as (
-    /* Priority 1: patch Needs overage. Bucket stays flagged upstream. */
+, emergency_step as (
+    /*
+        Priority 1: fund Emergency Fund contributions straight off the top of
+        extra_income. Caps at emergency_fund_assigned — recognizes the full EF
+        top-up actually made that year (gross assigned) before any overage patch,
+        so those dollars are claimed first rather than left for the surplus.
+    */
     select
         inputs.*
-        , greatest(0, needs_projected - needs_target) as needs_overage
-        , round(
-            least(extra_income, greatest(0, needs_projected - needs_target))
-            , 2
-          ) as extra_income_used_for_needs_overage
+        , round(least(extra_income, emergency_fund_assigned), 2)
+            as extra_income_used_for_emergency_fund_contributions
     from inputs
 )
 
+, needs_step as (
+    /* Priority 2: patch Needs overage with whatever remains after EF. */
+    select
+        emergency_step.*
+        , round(extra_income - extra_income_used_for_emergency_fund_contributions, 2)
+            as remaining_after_emergency
+        , greatest(0, needs_projected - needs_target) as needs_overage
+        , round(
+            least(
+                extra_income - extra_income_used_for_emergency_fund_contributions,
+                greatest(0, needs_projected - needs_target)
+            )
+            , 2
+          ) as extra_income_used_for_needs_overage
+    from emergency_step
+)
+
 , wants_step as (
-    /* Priority 2: patch Wants overage with whatever remains after Needs. */
+    /* Priority 3: patch Wants overage with whatever remains after Needs. */
     select
         needs_step.*
-        , round(extra_income - extra_income_used_for_needs_overage, 2)
+        , round(remaining_after_emergency - extra_income_used_for_needs_overage, 2)
             as remaining_after_needs
         , round(
             least(
-                extra_income - extra_income_used_for_needs_overage,
+                remaining_after_emergency - extra_income_used_for_needs_overage,
                 greatest(0, wants_projected - wants_target)
             )
             , 2
@@ -87,9 +127,9 @@ with bucket_pivot as (
 
 , savings_step as (
     /*
-        Priority 3: cover Savings withdrawals (spend only) with what remains.
-        Caps at savings_spent — coverage backfills withdrawn dollars, it never
-        funds new savings assignments or raises the savings target.
+        Priority 4: cover Savings withdrawals (spend only) with what remains
+        after Wants. Caps at savings_spent — coverage backfills withdrawn dollars,
+        it never funds new savings assignments or raises the savings target.
     */
     select
         wants_step.*
@@ -108,10 +148,11 @@ with bucket_pivot as (
 select
     year
     , extra_income
+    , extra_income_used_for_emergency_fund_contributions
     , extra_income_used_for_needs_overage
     , extra_income_used_for_wants_overage
     , extra_income_used_for_savings_coverage
-    /* Priority 4: surplus absorbs the remainder; the four outputs sum to extra_income. */
+    /* Priority 5: surplus absorbs the remainder; the five outputs sum to extra_income. */
     , round(remaining_after_wants - extra_income_used_for_savings_coverage, 2)
         as extra_income_surplus_to_investments
     /* Coverage-adjusted savings net saved (computed from the pre-coverage savings model's components). */


### PR DESCRIPTION
## What

Adds an always-on **Emergency Fund contributions** step as **priority 1** of the §8 extra-income waterfall in `core.yearly_extra_income_allocation`.

New waterfall order:
1. **Emergency Fund contributions (NEW)** — funded off the top of `extra_income`, capped at `emergency_fund_assigned`. Recognizes the full EF top-up made that year whenever extra income covers it.
2. Needs overage — remainder after EF.
3. Wants overage — remainder after Needs.
4. Savings coverage — remainder after Wants.
5. Investments surplus — the remainder.

## Why this shape (diverged from the ETH-479 spec)

- **Part A dropped.** A standalone `core.yearly_emergency_fund` leaf would have no consumers; its figure already lives in `dashboards.yearly_level.emergency_fund_saved`.
- **Contribution-funding, not spend-coverage.** The original spec covered EF *withdrawals*, of which there have been none — a permanent no-op. Flipped to fund EF *contributions*.
- **EF is priority 1.** Funding EF after Needs/Wants capped it by leftover extra income, so high-overage years under-recognized the contribution. Moving EF to the front funds the full assigned amount whenever extra income covers it.

## Details

- `extra_income_used_for_emergency_fund_contributions = least(extra_income, emergency_fund_assigned)`.
- `emergency_fund_assigned` = gross Emergency Fund group assignments, summed from `core.monthly_budgeted` over elapsed budget months, floored at 0. Actual YTD, not extrapolated.
- Source is a `_4` model (`core.monthly_budgeted`), keeping the dependency graph acyclic and avoiding a core → dashboards layering inversion.
- `yearly_extra_income_allocation_conservation` audit updated to the five-way sum (tolerance 0.02).

## Trade-off

EF taking its share first means Needs overage gets the remainder, so `needs_on_plan_after_allocation` can read false in tight high-overage years. Intended.

## Verification

- `sqlmesh plan` applied; audits pass (allocation 5, investment-contributions 6).
- Conservation holds for every year (five outputs sum to `extra_income`).
- `pre-commit run --all-files` clean; `pytest` 34 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)